### PR TITLE
Adding curl to livy-spark image

### DIFF
--- a/livy-spark/0.8.0-incubating-spark_3.0.1_2.12-hadoop_3.2.0_cloud/Dockerfile
+++ b/livy-spark/0.8.0-incubating-spark_3.0.1_2.12-hadoop_3.2.0_cloud/Dockerfile
@@ -36,7 +36,7 @@ ENV PATH                    $PATH:$LIVY_HOME/bin
 # install livy
 COPY --from=build /apache-livy-${LIVY_VERSION}-bin.zip /
 USER root
-RUN apt-get install -y unzip && \
+RUN apt-get install -y unzip curl && \
     unzip /apache-livy-${LIVY_VERSION}-bin.zip -d / && \
     mv /apache-livy-${LIVY_VERSION}-bin /opt/ && \
     rm -rf $LIVY_HOME && \


### PR DESCRIPTION
This example list under [https://github.com/JahstreetOrg/spark-on-kubernetes-helm]
does not work because curl is not present in image.
```
kubectl exec --namespace livy livy-0 -- \
    curl -s -k -H 'Content-Type: application/json' -X POST \
      -d '{
            "name": "SparkPi-01",
            "className": "org.apache.spark.examples.SparkPi",
            "numExecutors": 2,
            "file": "local:///opt/spark/examples/jars/spark-examples_2.11-2.4.5.jar",
            "args": ["10000"],
            "conf": {
                "spark.kubernetes.namespace": "livy"
            }
          }' "http://localhost:8998/batches" | jq
```
